### PR TITLE
Display a history of the last previous rolls

### DIFF
--- a/front/src/features/cyberpunk/Roller.js
+++ b/front/src/features/cyberpunk/Roller.js
@@ -66,6 +66,7 @@ const Roller = ({
               campaign,
               character,
               bbMessage: bbMessage({ description, total, parameters }),
+              description,
             });
           },
           error: ajaxError,

--- a/front/src/features/d10/D10Roller.js
+++ b/front/src/features/d10/D10Roller.js
@@ -162,6 +162,7 @@ const D10Roller = ({
               character,
               campaign,
               bbMessage: bbMessage({ description, roll }),
+              description,
             }),
           error: ajaxError,
         });

--- a/front/src/features/dnd/Roller.js
+++ b/front/src/features/dnd/Roller.js
@@ -102,6 +102,7 @@ export const Roller = ({
               bbMessage: bbMessage({ parameters, description, total }),
               campaign,
               character,
+              description,
             }),
           error: ajaxError,
         });

--- a/front/src/features/sw/Roller.js
+++ b/front/src/features/sw/Roller.js
@@ -102,6 +102,7 @@ const Roller = ({
           bbMessage: bbMessage({ id, description, dice, parameters, result }),
           campaign,
           character,
+          description,
         });
       },
       error: ajaxError,

--- a/front/src/features/unified/CopyAllButton.js
+++ b/front/src/features/unified/CopyAllButton.js
@@ -1,0 +1,29 @@
+import { Button, message } from "antd";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+
+const CopyAllButton = ({ results }) => {
+  const mergedBbCode = results
+    .map(({ id, bbMessage }) => {
+      if (!id || !bbMessage) {
+        return "";
+      }
+      return `[url=/r/${id}]${bbMessage}[/url]`;
+    })
+    .join("\n\n")
+    .trim();
+
+  if (!mergedBbCode) {
+    return null;
+  }
+
+  return (
+    <CopyToClipboard
+      text={mergedBbCode}
+      onCopy={() => message.success("Copied to clipboard!")}
+    >
+      <Button>{`Copy all rolls as BBCode`}</Button>
+    </CopyToClipboard>
+  );
+};
+
+export default CopyAllButton;

--- a/front/src/features/unified/Form.js
+++ b/front/src/features/unified/Form.js
@@ -23,9 +23,9 @@ const Form = ({
 
   const updateResult = (
     content,
-    { id, campaign, character, bbMessage } = {}
+    { id, campaign, character, bbMessage, description } = {}
   ) => {
-    setResult({ content, id, bbMessage });
+    setResult({ content, id, bbMessage, description });
     dispatch(addCampaign(campaign));
     dispatch(addCharacter(character));
     setError(false);

--- a/front/src/features/unified/PreviousResults.js
+++ b/front/src/features/unified/PreviousResults.js
@@ -1,0 +1,21 @@
+import styles from "./PreviousResults.module.less";
+import { Actions } from "./Result";
+
+const PreviousResults = ({ results }) => {
+  return (
+    <div>
+      <h4 className={styles.title}>{`Previously`}</h4>
+      {[...results].reverse().map(({ id, description, content, bbMessage }) => {
+        return (
+          <div key={id.toString()} className={styles.result}>
+            <p>{description}</p>
+            <div className={styles.core}>{content}</div>
+            <Actions id={id} bbMessage={bbMessage} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PreviousResults;

--- a/front/src/features/unified/PreviousResults.module.less
+++ b/front/src/features/unified/PreviousResults.module.less
@@ -10,6 +10,8 @@
 
   p {
     margin: 0;
+    margin-bottom: 12px;
+    white-space: pre-line;
   }
 
   .core {

--- a/front/src/features/unified/PreviousResults.module.less
+++ b/front/src/features/unified/PreviousResults.module.less
@@ -1,0 +1,18 @@
+@import (reference) "common.less";
+
+.title {
+  .block-title();
+}
+
+.result {
+  .torii-box-light();
+  margin: 0 12px 8px;
+
+  p {
+    margin: 0;
+  }
+
+  .core {
+    text-align: center;
+  }
+}

--- a/front/src/features/unified/Result.js
+++ b/front/src/features/unified/Result.js
@@ -4,21 +4,29 @@ import Loader from "features/navigation/Loader";
 import { Link } from "react-router-dom";
 import CopyButtons from "components/aftermath/CopyButtons";
 
+export const Actions = ({ id, bbMessage }) => {
+  if (!id) {
+    return null;
+  }
+
+  return (
+    <div className={styles.buttons}>
+      <>
+        <CopyButtons
+          link={`${window.location.origin}/r/${id}`}
+          bbMessage={bbMessage}
+        />
+        <Link to={`/r/${id}`}>{`Go to page`}</Link>
+      </>
+    </div>
+  );
+};
+
 const Result = ({ id, bbMessage, content }) => {
   return (
     <div className={styles.result}>
       <>{content}</>
-      {!!id && (
-        <div className={styles.buttons}>
-          <>
-            <CopyButtons
-              link={`${window.location.origin}/r/${id}`}
-              bbMessage={bbMessage}
-            />
-            <Link to={`/r/${id}`}>{`Go to page`}</Link>
-          </>
-        </div>
-      )}
+      <Actions id={id} bbMessage={bbMessage} />
     </div>
   );
 };

--- a/front/src/features/unified/Roller.js
+++ b/front/src/features/unified/Roller.js
@@ -6,6 +6,7 @@ import DefaultErrorMessage from "DefaultErrorMessage";
 import Selector from "./Selector";
 import PreviousResults from "./PreviousResults";
 import CopyAllButton from "./CopyAllButton";
+import { Button } from "antd";
 
 const Roller = ({ rollType }) => {
   const [loading, setLoading] = useState(false);
@@ -48,8 +49,11 @@ const Roller = ({ rollType }) => {
         <Result loading={loading} result={result} />
         {resultHistory.length > 1 && (
           <>
-            <div>
+            <div className={styles.buttons}>
               <CopyAllButton results={resultHistory} />
+              <Button
+                onClick={() => setResultHistory([])}
+              >{`Clear history`}</Button>
             </div>
             <PreviousResults results={previousResults()} />
           </>

--- a/front/src/features/unified/Roller.js
+++ b/front/src/features/unified/Roller.js
@@ -1,14 +1,33 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import styles from "./Roller.module.less";
 import Result from "./Result";
 import Form from "./Form";
 import DefaultErrorMessage from "DefaultErrorMessage";
 import Selector from "./Selector";
+import PreviousResults from "./PreviousResults";
 
 const Roller = ({ rollType }) => {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState();
   const [error, setError] = useState(false);
+  const [resultHistory, setResultHistory] = useState([]);
+
+  const setR = useCallback(
+    (data) => {
+      setResult(data);
+      if (!!data?.id) {
+        setResultHistory((previous) => [...previous, data]);
+      }
+    },
+    [setResult, setResultHistory]
+  );
+
+  const previousResults = () => {
+    if (!!result) {
+      return resultHistory.filter(({ id }) => id !== result.id);
+    }
+    return resultHistory;
+  };
 
   if (error) {
     return <DefaultErrorMessage />;
@@ -22,10 +41,13 @@ const Roller = ({ rollType }) => {
           rollType={rollType}
           loading={loading}
           setLoading={setLoading}
-          setResult={setResult}
+          setResult={setR}
           setError={setError}
         />
         <Result loading={loading} result={result} />
+        {resultHistory.length > 1 && (
+          <PreviousResults results={previousResults()} />
+        )}
       </div>
     </div>
   );

--- a/front/src/features/unified/Roller.js
+++ b/front/src/features/unified/Roller.js
@@ -5,6 +5,7 @@ import Form from "./Form";
 import DefaultErrorMessage from "DefaultErrorMessage";
 import Selector from "./Selector";
 import PreviousResults from "./PreviousResults";
+import CopyAllButton from "./CopyAllButton";
 
 const Roller = ({ rollType }) => {
   const [loading, setLoading] = useState(false);
@@ -46,7 +47,12 @@ const Roller = ({ rollType }) => {
         />
         <Result loading={loading} result={result} />
         {resultHistory.length > 1 && (
-          <PreviousResults results={previousResults()} />
+          <>
+            <div>
+              <CopyAllButton results={resultHistory} />
+            </div>
+            <PreviousResults results={previousResults()} />
+          </>
         )}
       </div>
     </div>

--- a/front/src/features/unified/Roller.module.less
+++ b/front/src/features/unified/Roller.module.less
@@ -32,4 +32,10 @@
       margin-bottom: 12px;
     }
   }
+
+  .buttons {
+    & > * {
+      margin-right: 12px;
+    }
+  }
 }


### PR DESCRIPTION
![Screenshot 2023-11-14 at 00-00-26 Sakkaku](https://github.com/ceithir/sakkaku/assets/896729/c8dcdcf2-664a-4ad6-9922-192bc81d41d0)

- Show rolls done in the recent past (i.e. without reloading page) below current roll
- Allow to copy the BbCode of all these rolls at once